### PR TITLE
Add `linkerd smi check` sub command

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+const (
+
+	// linkerdSMIExtensionCheck adds checks related to the SMI extension
+	linkerdSMIExtensionCheck healthcheck.CategoryID = "linkerd-smi"
+)
+
+var (
+	smiNamespace string
+)
+
+type checkOptions struct {
+	wait      time.Duration
+	output    string
+	proxy     bool
+	namespace string
+}
+
+func smiCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
+
+	checkers := []healthcheck.Checker{}
+
+	checkers = append(checkers,
+		*healthcheck.NewChecker("linkerd-smi extension Namespace exists").
+			WithHintAnchor("l5d-smi-ns-exists").
+			Fatal().
+			WithCheck(func(ctx context.Context) error {
+				// Get SMI Extension Namespace
+				ns, err := hc.KubeAPIClient().GetNamespaceWithExtensionLabel(ctx, smiExtensionName)
+				if err != nil {
+					return err
+				}
+				smiNamespace = ns.Name
+				return nil
+			}))
+
+	checkers = append(checkers,
+		*healthcheck.NewChecker("SMI extension service account exists").
+			WithHintAnchor("l5d-smi-sc-exists").
+			Fatal().
+			Warning().
+			WithCheck(func(ctx context.Context) error {
+				// Check for Collector Service Account
+				return healthcheck.CheckServiceAccounts(ctx, hc.KubeAPIClient(), []string{"smi-adaptor"}, smiNamespace, "")
+			}))
+
+	checkers = append(checkers,
+		*healthcheck.NewChecker("SMI extension pods are injected").
+			WithHintAnchor("l5d-smi-pods-injection").
+			Warning().
+			WithCheck(func(ctx context.Context) error {
+				// Check if SMI Extension pods have been injected
+				pods, err := hc.KubeAPIClient().GetPodsByNamespace(ctx, smiNamespace)
+				if err != nil {
+					return err
+				}
+				return healthcheck.CheckIfDataPlanePodsExist(pods)
+			}))
+
+	checkers = append(checkers,
+		*healthcheck.NewChecker("SMI extension pods are running").
+			WithHintAnchor("l5d-smi-pods-running").
+			Fatal().
+			WithRetryDeadline(hc.RetryDeadline).
+			SurfaceErrorOnRetry().
+			WithCheck(func(ctx context.Context) error {
+				pods, err := hc.KubeAPIClient().GetPodsByNamespace(ctx, smiNamespace)
+				if err != nil {
+					return err
+				}
+
+				// Check for relevant pods to be present
+				err = healthcheck.CheckForPods(pods, []string{"smi-adaptor"})
+				if err != nil {
+					return err
+				}
+
+				return healthcheck.CheckPodsRunning(pods, "")
+
+			}))
+
+	checkers = append(checkers,
+		*healthcheck.NewChecker("SMI extension proxies are healthy").
+			WithHintAnchor("l5d-smi-proxy-healthy").
+			Fatal().
+			WithRetryDeadline(hc.RetryDeadline).
+			SurfaceErrorOnRetry().
+			WithCheck(func(ctx context.Context) error {
+				return hc.CheckProxyHealth(ctx, hc.ControlPlaneNamespace, smiNamespace)
+			}))
+
+	checkers = append(checkers,
+		*healthcheck.NewChecker("SMI extension proxies are up-to-date").
+			WithHintAnchor("l5d-smi-proxy-cp-version").
+			Warning().
+			WithCheck(func(ctx context.Context) error {
+				var err error
+				if hc.VersionOverride != "" {
+					hc.LatestVersions, err = version.NewChannels(hc.VersionOverride)
+				} else {
+					uuid := "unknown"
+					if hc.UUID() != "" {
+						uuid = hc.UUID()
+					}
+					hc.LatestVersions, err = version.GetLatestVersions(ctx, uuid, "cli")
+				}
+				if err != nil {
+					return err
+				}
+
+				pods, err := hc.KubeAPIClient().GetPodsByNamespace(ctx, smiNamespace)
+				if err != nil {
+					return err
+				}
+
+				return hc.CheckProxyVersionsUpToDate(pods)
+			}))
+
+	checkers = append(checkers,
+		*healthcheck.NewChecker("SMI extension proxies and cli versions match").
+			WithHintAnchor("l5d-smi-proxy-cli-version").
+			Warning().
+			WithCheck(func(ctx context.Context) error {
+				pods, err := hc.KubeAPIClient().GetPodsByNamespace(ctx, smiNamespace)
+				if err != nil {
+					return err
+				}
+
+				return healthcheck.CheckIfProxyVersionsMatchWithCLI(pods)
+			}))
+
+	return healthcheck.NewCategory(linkerdSMIExtensionCheck, checkers, true)
+}
+
+func newCheckOptions() *checkOptions {
+	return &checkOptions{
+		wait:   300 * time.Second,
+		output: healthcheck.TableOutput,
+	}
+}
+
+func (options *checkOptions) validate() error {
+	if options.output != healthcheck.TableOutput && options.output != healthcheck.JSONOutput {
+		return fmt.Errorf("Invalid output type '%s'. Supported output types are: %s, %s", options.output, healthcheck.JSONOutput, healthcheck.TableOutput)
+	}
+	return nil
+}
+
+// newCmdCheck generates a new cobra command for the SMI extension.
+func newCmdCheck() *cobra.Command {
+	options := newCheckOptions()
+	cmd := &cobra.Command{
+		Use:   "check [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Check the SMI extension for potential problems",
+		Long: `Check the SMI extension for potential problems.
+
+The check command will perform a series of checks to validate that the SMI
+extension is configured correctly. If the command encounters a failure it will
+print additional information about the failure and exit with a non-zero exit
+code.`,
+		Example: `  # Check that the SMI extension is up and running
+  linkerd smi check`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return configureAndRunChecks(stdout, stderr, options)
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "Output format. One of: basic, json")
+	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
+	cmd.Flags().BoolVar(&options.proxy, "proxy", options.proxy, "Also run data-plane checks, to determine if the data plane is healthy")
+	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
+
+	return cmd
+}
+
+func configureAndRunChecks(wout io.Writer, werr io.Writer, options *checkOptions) error {
+	err := options.validate()
+	if err != nil {
+		return fmt.Errorf("Validation error when executing check command: %v", err)
+	}
+
+	hc := healthcheck.NewHealthChecker([]healthcheck.CategoryID{}, &healthcheck.Options{
+		ControlPlaneNamespace: controlPlaneNamespace,
+		KubeConfig:            kubeconfigPath,
+		KubeContext:           kubeContext,
+		Impersonate:           impersonate,
+		ImpersonateGroup:      impersonateGroup,
+		APIAddr:               apiAddr,
+		RetryDeadline:         time.Now().Add(options.wait),
+		DataPlaneNamespace:    options.namespace,
+	})
+
+	err = hc.InitializeKubeAPIClient()
+	if err != nil {
+		err = fmt.Errorf("Error initializing k8s API client: %s", err)
+		fmt.Fprintln(werr, err)
+		os.Exit(1)
+	}
+
+	hc.AppendCategories(smiCategory(hc))
+
+	success := healthcheck.RunChecks(wout, werr, hc, options.output)
+
+	if !success {
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -26,6 +26,7 @@ type checkOptions struct {
 	output    string
 	proxy     bool
 	namespace string
+	pre       string
 }
 
 func smiCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
@@ -142,7 +143,11 @@ code.`,
 	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.Flags().BoolVar(&options.proxy, "proxy", options.proxy, "Also run data-plane checks, to determine if the data plane is healthy")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
+	cmd.Flags().StringVar(&options.pre, "pre", options.namespace, "Only run pre-installation checks, to determine if the extension can be installed")
 
+	// stop marking these flags as hidden, once they are being supported
+	cmd.Flags().MarkHidden("pre")
+	cmd.Flags().MarkHidden("proxy")
 	return cmd
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/fatih/color"
 	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -16,6 +17,12 @@ const (
 )
 
 var (
+
+	// special handling for Windows, on all other platforms these resolve to
+	// os.Stdout and os.Stderr, thanks to https://github.com/mattn/go-colorable
+	stdout = color.Output
+	stderr = color.Error
+
 	apiAddr               string // An empty value means "use the Kubernetes configuration"
 	controlPlaneNamespace string
 	kubeconfigPath        string
@@ -61,6 +68,7 @@ func NewCmdSMI() *cobra.Command {
 	smiCmd.AddCommand(newCmdInstall())
 	smiCmd.AddCommand(newCmdUninstall())
 	smiCmd.AddCommand(newCmdVersion())
+	smiCmd.AddCommand(newCmdCheck())
 
 	// resource-aware completion flag configurations
 	pkgcmd.ConfigureNamespaceFlagCompletion(

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/linkerd/linkerd-smi
 go 1.16
 
 require (
+	github.com/fatih/color v1.9.0
 	github.com/linkerd/linkerd2 v0.0.0-20210617063832-395cc3677e31
 	github.com/servicemeshinterface/smi-sdk-go v0.4.1
 	github.com/sirupsen/logrus v1.7.0

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -51,11 +51,11 @@ func TestTrafficSplitsConversionWithSMIAdaptor(t *testing.T) {
 			"'kubectl apply' command failed\n%s", out)
 	}
 
-	o, err := TestHelper.Kubectl("", "--namespace=linkerd", "rollout", "status", "--timeout=60m", "deploy/linkerd-destination")
+	out, err = TestHelper.Kubectl("", "--namespace=linkerd", "rollout", "status", "--timeout=60m", "deploy/linkerd-destination")
 	if err != nil {
 		linkerdtestutil.AnnotatedFatalf(t,
 			"failed to wait rollout of deploy/linkerd-destination",
-			"failed to wait for rollout of deploy/linkerd-destination: %s: %s", err, o)
+			"failed to wait for rollout of deploy/linkerd-destination: %s: %s", err, out)
 	}
 
 	// Install SMI extension
@@ -70,11 +70,10 @@ func TestTrafficSplitsConversionWithSMIAdaptor(t *testing.T) {
 			"'kubectl apply' command failed\n%s", out)
 	}
 
-	o, err = TestHelper.Kubectl("", "--namespace=linkerd-smi", "rollout", "status", "--timeout=60m", "deploy/smi-adaptor")
+	out, err = TestHelper.LinkerdSMIRun("check")
 	if err != nil {
-		linkerdtestutil.AnnotatedFatalf(t,
-			"failed to wait rollout of deploy/smi-adaptor",
-			"failed to wait for rollout of deploy/smi-adaptor: %s: %s", err, o)
+		linkerdtestutil.AnnotatedFatalf(t, "'linkerd smi check' command failed",
+			"'linkerd smi check' command failed\n%s", out)
 	}
 
 	// Create the namespace


### PR DESCRIPTION
This PR adds a new check sub command which is used to perform
a check, and make sure that the SMI components are installed
and functioning correctly.

This follows the same pattern of check that we use in viz, jaeger, etc
other extensions.

This PR also updates the integration test to use the command, instead
of doing a `kubectl rollout status`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
