### PR TITLE
readme: fix actions workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # linkerd-smi
 
-[![Actions](https://github.com/linkerd/linkerd-smi/actions/workflows/actions.yml/badge.svg)](https://github.com/linkerd/linkerd-smi/actions/workflows/actions.yml)
+[![Actions](https://github.com/linkerd/linkerd-smi/actions/workflows/integration_tests.yml/badge.svg)](https://github.com/linkerd/linkerd-smi/actions/workflows/integration_tests.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/linkerd/linkerd-smi)](https://goreportcard.com/report/github.com/linkerd/linkerd-smi)
 [![GitHub license](https://img.shields.io/github/license/linkerd/linkerd-smi.svg)](LICENSE)
 


### PR DESCRIPTION
This PR updates the README to use the `integration_tests` workflow
for the status badge generation.

I tried to find if there was a way to show the status based on
multiple workflows to show accurate status (i.e `unit_tests`, etc in
our case) but GitHub doesn't seem to support that yet.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
