### PR TITLE
controller: add configuration to set number of workers

### DIFF
--- a/adaptor/main.go
+++ b/adaptor/main.go
@@ -24,6 +24,7 @@ func main() {
 	kubeConfigPath := cmd.String("kubeconfig", "", "path to kube config")
 	metricsAddr := cmd.String("metrics-addr", ":9995", "address to serve scrapable metrics on")
 	clusterDomain := cmd.String("cluster-domain", "cluster.local", "kubernetes cluster domain")
+	workers := cmd.Int("worker-threads", 2, "number of concurrent goroutines to process the workqueue")
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
@@ -72,6 +73,7 @@ func main() {
 		tsClient,
 		spClient,
 		tsInformerFactory.Split().V1alpha1().TrafficSplits(),
+		*workers,
 	)
 
 	// Start the Admin Server

--- a/pkg/adaptor/controller_test.go
+++ b/pkg/adaptor/controller_test.go
@@ -105,6 +105,7 @@ func TestController(t *testing.T) {
 				tsClient,
 				spClient,
 				tsInformer.Split().V1alpha1().TrafficSplits(),
+				2,
 			)
 
 			for _, ts := range tt.tsUpdates {


### PR DESCRIPTION
Currently, We only have a single goroutine i.e worker that processes
items from the workqueue. But there is nothing preventing us from
having multiple goroutines processing items from workqueues. and one
of the benefit of doing this whole workqueue way is to be able to
process concurrently.

This PR adds a new `worker-threads` CLI flag to controller, to override
the default number of goroutines i.e 2.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
