### PR TITLE
controller: use a struct as workqueue item

### DIFF
--- a/pkg/adaptor/controller_test.go
+++ b/pkg/adaptor/controller_test.go
@@ -114,7 +114,12 @@ func TestController(t *testing.T) {
 
 			// Handle TS objects
 			for _, ts := range tt.tsUpdates {
-				controller.syncHandler(ctx, trafficSplitKeyFunc(*ts))
+				controller.syncHandler(ctx,
+					trafficSplitKey{
+						name:      ts.Name,
+						namespace: ts.Namespace,
+						service:   ts.Spec.Service,
+					})
 			}
 
 			// Match expectedServiceProfiles with the ones in the cluster


### PR DESCRIPTION
Currently, We use a string as the item for the workqueue, which
is encoded from a TS and decoded to a TS. This is done, instead
of passing the full TS into the workqueue and using it, because of
updates that could happen and hence the latest has to be fetched always
in `SyncHandler`.

This PR, removes the additional encoding and decoding work by using
a struct in its place, and thus removing the need for decoding.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
