### PR TITLE
Support multi-arch builds

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         mkdir -p $ARCHIVES
         docker save "cr.l5d.io/linkerd/smi-adaptor:$TAG" > $ARCHIVES/smi-adaptor.tar
-        cp target/cli/linux-amd64/linkerd-smi $ARCHIVES
+        cp target/cli/linkerd-smi-linux-amd64 $ARCHIVES
     - name: Upload artifact
       uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5
       with:
@@ -87,7 +87,7 @@ jobs:
       run: |
         mkdir -p $HOME/.linkerd2/bin
         echo "$HOME/.linkerd2/bin" >> $GITHUB_PATH
-        mv build-archives/linkerd-smi "$HOME/.linkerd2/bin"
+        mv build-archives/linkerd-smi-linux-amd64 "$HOME/.linkerd2/bin/linkerd-smi"
         chmod +x $HOME/.linkerd2/bin/linkerd-smi
 
         # load image into the cluster

--- a/bin/_os.sh
+++ b/bin/_os.sh
@@ -4,48 +4,44 @@ set -eu
 
 os() {
   os=$(uname -s)
-  arch=""
   case $os in
     CYGWIN* | MINGW64*)
-      os=windows
+      echo "windows"
       ;;
     Darwin)
-      os=darwin
+      echo "darwin"
       ;;
     Linux)
-      os=linux
-      arch=$(uname -m)
-      case $arch in
-        x86_64)
-          arch=amd64
-          ;;
-        armv8*)
-          arch=arm64
-          ;;
-        aarch64*)
-          arch=arm64
-          ;;
-        armv*)
-          arch=arm
-          ;;
-        amd64|arm64)
-          arch=$arch
-          ;;
-        *)
-          echo "unsupported architecture: $arch" >&2
-          exit 1
-          ;;
-      esac
+      echo "linux"
       ;;
     *)
       echo "unsupported os: $os" >&2
       exit 1
       ;;
   esac
+}
 
-  if [ -n "$arch" ]; then
-    echo "$os-$arch"
-  else
-    echo "$os"
-  fi
+arch() {
+  arch=$(uname -m)
+  case $arch in
+    x86_64)
+      echo "amd64"
+      ;;
+    armv8*)
+      echo "arm64"
+      ;;
+    aarch64*)
+      echo "arm64"
+      ;;
+    armv*)
+      echo "arm"
+      ;;
+    amd64|arm64)
+      echo $arm
+      ;;
+    *)
+      echo "unsupported architecture: $arch" >&2
+      exit 1
+      ;;
+      esac
 }

--- a/bin/_os.sh
+++ b/bin/_os.sh
@@ -37,7 +37,7 @@ arch() {
       echo "arm"
       ;;
     amd64|arm64)
-      echo $arch
+      echo "$arch"
       ;;
     *)
       echo "unsupported architecture: $arch" >&2

--- a/bin/_os.sh
+++ b/bin/_os.sh
@@ -37,7 +37,7 @@ arch() {
       echo "arm"
       ;;
     amd64|arm64)
-      echo $arm
+      echo $arch
       ;;
     *)
       echo "unsupported architecture: $arch" >&2

--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -25,7 +25,7 @@ export CLI_MULTIARCH=${CLI_MULTIARCH:-}
         CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $target/linkerd-smi-darwin-arm64 -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
         CGO_ENABLED=0 GOOS=windows go build -o $target/linkerd-smi-windows -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
     else
-        CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) go build -o $target/linkerd-smi-$(os)-$(arch) -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+        CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) go build -o "$target/linkerd-smi-$(os)-$(arch)" -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
         echo "$target/linkerd-smi-$(os)-$(arch)"
     fi
 )

--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -16,7 +16,7 @@ export CLI_MULTIARCH=${CLI_MULTIARCH:-}
     cd "$(pwd -P)"
     target=target/cli
      # TODO: `go generate` does not honor -mod=readonly
-    GO111MODULE=on go generate -mod=readonly ./pkg/static
+    go generate -mod=readonly ./pkg/static
     root_tag=$("$bindir"/root-tag)
     GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd-smi/pkg/version.Version=$root_tag"
     if [ -n "$CLI_MULTIARCH" ]; then

--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -19,11 +19,13 @@ export CLI_MULTIARCH=${CLI_MULTIARCH:-}
     GO111MODULE=on go generate -mod=readonly ./pkg/static
     root_tag=$("$bindir"/root-tag)
     GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd-smi/pkg/version.Version=$root_tag"
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $target/linkerd-smi-linux-amd64 -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
     if [ -n "$CLI_MULTIARCH" ]; then
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $target/linkerd-smi-linux-amd64 -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
         CGO_ENABLED=0 GOOS=darwin go build -o $target/linkerd-smi-darwin -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
         CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $target/linkerd-smi-darwin-arm64 -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
         CGO_ENABLED=0 GOOS=windows go build -o $target/linkerd-smi-windows -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+    else
+        CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) go build -o $target/linkerd-smi-$(os)-$(arch) -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+        echo "$target/linkerd-smi-$(os)-$(arch)"
     fi
-    echo "$target/linkerd-smi-linux-amd64"
 )

--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -9,13 +9,21 @@ rootdir=$( cd "$bindir"/.. && pwd )
 # shellcheck source=_os.sh
 . "$bindir"/_os.sh
 
+# build the multi-arch CLI binaries
+export CLI_MULTIARCH=${CLI_MULTIARCH:-}
 (
     cd "$rootdir"
     cd "$(pwd -P)"
-    target=target/cli/$(os)/linkerd-smi
+    target=target/cli
      # TODO: `go generate` does not honor -mod=readonly
     GO111MODULE=on go generate -mod=readonly ./pkg/static
     root_tag=$("$bindir"/root-tag)
-    GO111MODULE=on CGO_ENABLED=0 go build -o "$target" -tags production -mod=readonly  -ldflags "-s -w -X github.com/linkerd/linkerd-smi/pkg/version.Version=$root_tag" ./cli
-    echo "$target"
+    GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd-smi/pkg/version.Version=$root_tag"
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $target/linkerd-smi-linux-amd64 -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+    if [ -n "$CLI_MULTIARCH" ]; then
+        CGO_ENABLED=0 GOOS=darwin go build -o $target/linkerd-smi-darwin -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+        CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $target/linkerd-smi-darwin-arm64 -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+        CGO_ENABLED=0 GOOS=windows go build -o $target/linkerd-smi-windows -tags production -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+    fi
+    echo "$target/linkerd-smi-linux-amd64"
 )

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -8,8 +8,15 @@ if [ $# -ne 0 ]; then
 fi
 
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-cr.l5d.io/linkerd}
+
 # buildx cache directory
 export DOCKER_BUILDKIT_CACHE=${DOCKER_BUILDKIT_CACHE:-}
+
+# build the multi-arch images
+export DOCKER_MULTIARCH=${DOCKER_MULTIARCH:-}
+
+# Default supported docker image architectures
+export SUPPORTED_ARCHS=${SUPPORTED_ARCHS:-linux/amd64,linux/arm64,linux/arm/v7}
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
@@ -22,8 +29,14 @@ if [ -n "$DOCKER_BUILDKIT_CACHE" ]; then
     cache_params="--cache-from type=local,src=${DOCKER_BUILDKIT_CACHE} --cache-to type=local,dest=${DOCKER_BUILDKIT_CACHE},mode=max"
 fi
 
+output_params=""
+if [ -n "$DOCKER_MULTIARCH" ]; then
+    output_params="--platform $SUPPORTED_ARCHS"
+fi
+
 # shellcheck disable=SC2086
 docker buildx build "$rootdir" $cache_params \
+    $output_params \
     --load \
     -t "$DOCKER_REGISTRY/smi-adaptor:$(head_root_tag)" \
     -f "$rootdir/adaptor/Dockerfile" \


### PR DESCRIPTION
This PR updates the `docker-build` and `build-cli-bin` scripts
to support multi-arch builds. These are enabled by using
`DOCKER_MULTIARCH` and `CLI_MULTIARCH` environment variables
respectively.

In the `build-cli-bin` when `CLI_MULTIARCH` is not enabled
i.e default case, we just build the CLI binary for the current system
OS architecture

**These env variables are not used yet, and will be used
in the release workflow, which will be a separate PR***

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
