### PR TITLE
Update docker registry to `cr.l5d.io`

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,7 +27,6 @@ jobs:
         . bin/_tag.sh
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
 
-        echo "DOCKER_REGISTRY=cr.l5d.io/linkerd" >> $GITHUB_ENV
         echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
     - name: Cache docker layers
       uses: actions/cache@b8204782bbb5f872091ecc5eb9cb7d004e35b1fa

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,7 +27,7 @@ jobs:
         . bin/_tag.sh
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
 
-        echo "DOCKER_REGISTRY=ghcr.io/linkerd" >> $GITHUB_ENV
+        echo "DOCKER_REGISTRY=cr.l5d.io/linkerd" >> $GITHUB_ENV
         echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
     - name: Cache docker layers
       uses: actions/cache@b8204782bbb5f872091ecc5eb9cb7d004e35b1fa
@@ -46,7 +46,7 @@ jobs:
         ARCHIVES: /home/runner/archives
       run: |
         mkdir -p $ARCHIVES
-        docker save "ghcr.io/linkerd/smi-adaptor:$TAG" > $ARCHIVES/smi-adaptor.tar
+        docker save "cr.l5d.io/linkerd/smi-adaptor:$TAG" > $ARCHIVES/smi-adaptor.tar
         cp target/cli/linkerd-smi-linux-amd64 $ARCHIVES
     - name: Upload artifact
       uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 env:
   GH_ANNOTATION: true
-  DOCKER_REGISTRY: ghcr.io/linkerd
+  DOCKER_REGISTRY: cr.l5d.io/linkerd
 jobs:
   docker_build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ permissions:
   contents: write
 env:
   GH_ANNOTATION: true
-  DOCKER_REGISTRY: cr.l5d.io/linkerd
 jobs:
   docker_build:
     runs-on: ubuntu-20.04
@@ -24,6 +23,7 @@ jobs:
     - name: Set environment variables from scripts
       run: |
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
+        echo "DOCKER_REGISTRY=ghcr.io/linkerd" >> $GITHUB_ENV
         echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
     - name: Cache docker layers
       uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -7,7 +7,7 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-export DOCKER_REGISTRY=${DOCKER_REGISTRY:-ghcr.io/linkerd}
+export DOCKER_REGISTRY=${DOCKER_REGISTRY:-cr.l5d.io/linkerd}
 
 # buildx cache directory
 export DOCKER_BUILDKIT_CACHE=${DOCKER_BUILDKIT_CACHE:-}

--- a/charts/linkerd-smi/README.md
+++ b/charts/linkerd-smi/README.md
@@ -66,7 +66,7 @@ Kubernetes: `>=1.16.0-0`
 |-----|------|---------|-------------|
 | adaptor.image.name | string | `"smi-adaptor"` | Docker image name for the adaptor instance |
 | adaptor.image.pullPolicy | string | `"IfNotPresent"` | Pull policy  for the adaptor instance |
-| adaptor.image.registry | string | `"ghcr.io/linkerd"` | Docker registry for the adaptor instance |
+| adaptor.image.registry | string | `"cr.l5d.io/linkerd"` | Docker registry for the adaptor instance |
 | adaptor.image.tag | string | `"linkerdSMIVersionValue"` | Docker image tag for the adaptor instance |
 | clusterDomain | string | `"cluster.local"` | Kubernetes DNS Domain name to use |
 | installNamespace | bool | `true` | Set to false when installing in a custom namespace |

--- a/charts/linkerd-smi/values.yaml
+++ b/charts/linkerd-smi/values.yaml
@@ -11,7 +11,7 @@ clusterDomain: cluster.local
 adaptor:
   image:
     # -- Docker registry for the adaptor instance
-    registry: ghcr.io/linkerd
+    registry: cr.l5d.io/linkerd
     # -- Docker image name for the adaptor instance
     name: smi-adaptor
     # -- Docker image tag for the adaptor instance

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -34,7 +34,7 @@ spec:
       - args:
         - smi-adaptor
         - -cluster-domain=cluster.local
-        image: ghcr.io/linkerd/smi-adaptor:dev-undefined
+        image: cr.l5d.io/linkerd/smi-adaptor:dev-undefined
         imagePullPolicy: IfNotPresent
         name: smi-adaptor
         ports:

--- a/cli/cmd/testdata/install_override_namespace.golden
+++ b/cli/cmd/testdata/install_override_namespace.golden
@@ -34,7 +34,7 @@ spec:
       - args:
         - smi-adaptor
         - -cluster-domain=cluster.local
-        image: ghcr.io/linkerd/smi-adaptor:dev-undefined
+        image: cr.l5d.io/linkerd/smi-adaptor:dev-undefined
         imagePullPolicy: IfNotPresent
         name: smi-adaptor
         ports:


### PR DESCRIPTION
This PR updates the docker registry to be `cr.l5d.io` to make
it consistent with that of the main docker images.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
