### PR TITLE
controller: add events to the TrafficSplit resources

### DIFF
--- a/charts/linkerd-smi/templates/rbac.yaml
+++ b/charts/linkerd-smi/templates/rbac.yaml
@@ -10,6 +10,9 @@ metadata:
     linkerd.io/extension: smi
     component: smi-adaptor
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
   verbs: ["list", "get", "create", "update"]

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -53,6 +53,9 @@ metadata:
     linkerd.io/extension: smi
     component: smi-adaptor
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
   verbs: ["list", "get", "create", "update"]

--- a/cli/cmd/testdata/install_override_namespace.golden
+++ b/cli/cmd/testdata/install_override_namespace.golden
@@ -53,6 +53,9 @@ metadata:
     linkerd.io/extension: smi
     component: smi-adaptor
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
   verbs: ["list", "get", "create", "update"]

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.3
 	helm.sh/helm/v3 v3.4.1
+	k8s.io/api v0.19.3
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v0.19.3
 )


### PR DESCRIPTION
This PR updates the controller to add events to the TrafficSplit
resource based on the changes done by the controller. Currently,
These include `Created` and `Updated` respectively.

Example Events:

```bash
Events:
  Type    Reason   Age   From            Message
  ----    ------   ----  ----            -------
  Normal  Created  55s   smi-controller  Created Service Profile backend-svc.default.svc.cluster.local
  Normal  Updated  1s    smi-controller  Updated Service Profile backend-svc.default.svc.cluster.local
```

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
