### PR TITLE
Update README and chart versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,18 @@ Alternatively, you can download the CLI directly via the
 To install the linkerd-smi Helm chart, run:
 
     helm repo add l5d-smi https://linkerd.github.io/linkerd-smi
-    helm install l5d-smi/linkerd-smi --generate-name
+    helm install linkers-smi -n --create-namespace l5d-smi/linkerd-smi
+
+## Compatibility matrix
+
+| linkerd-smi | linkerd stable    | linkerd edge              |
+| ----------- | ----------------- | -------- ---------------- |
+| v0.1.0      | 2.11 and previous | edge-21.12.1 and previous |
+| v0.2.0      | 2.12.0 and later  | edge-21.12.2 and later    |
 
 ## License
 
-Copyright 2021 the Linkerd Authors. All rights reserved.
+Copyright 2021-2022 the Linkerd Authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -35,7 +35,6 @@ if [ "$1" = package ]; then
                 exit 1
     fi
     fullVersion=${BASH_REMATCH[0]}
-    version=${BASH_REMATCH[1]}
 
     # set version in Values files
     setValues "linkerdSMIVersionValue" "$fullVersion"

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -40,7 +40,7 @@ if [ "$1" = package ]; then
     # set version in Values files
     setValues "linkerdSMIVersionValue" "$fullVersion"
 
-    "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd-smi
+    "$bindir"/helm --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd-smi
     "$bindir"/helm repo index --url "https://linkerd.github.io/linkerd-smi/" "$rootdir"/target/helm
 
     # restore version in Values files

--- a/charts/linkerd-smi/Chart.yaml
+++ b/charts/linkerd-smi/Chart.yaml
@@ -9,8 +9,7 @@ kubeVersion: ">=1.16.0-0"
 name: linkerd-smi
 sources:
 - https://github.com/linkerd/linkerd-smi/
-# this version will be updated by the CI before publishing the Helm tarball
-version: 0.1.0
+version: 1.0.0
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-smi/README.md
+++ b/charts/linkerd-smi/README.md
@@ -2,7 +2,7 @@
 
 The Linkerd-SMI extension adds SMI adaptor to the Linkerd install
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 


### PR DESCRIPTION
- Separate `version` from `appVersion` in the Helm chart, as done in the
  linkerd2 repo
- Updated README.md with a compatibility matrix and a helm command with
  proper namespacing
