### PR TITLE
Update integration test to work with new Linkerd helm charts

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -126,10 +126,19 @@ func TestSMIAdaptorWithHelm(t *testing.T) {
 		"--set", "identity.issuer.tls.crtPEM=" + helmTLSCerts.Cred.Crt.EncodeCertificatePEM(),
 		"--set", "identity.issuer.tls.keyPEM=" + helmTLSCerts.Cred.EncodePrivateKeyPEM(),
 		"--set", "identity.issuer.crtExpiry=" + helmTLSCerts.Cred.Crt.Certificate.NotAfter.Format(time.RFC3339),
+		"--namespace", "linkerd",
+		"--create-namespace",
+		"--devel",
 	}
 
-	if stdout, stderr, err := TestHelper.HelmInstall("linkerd-edge/linkerd2", "linkerd", args...); err != nil {
-		linkerdtestutil.AnnotatedFatalf(t, "'helm install' command failed\n%s\n%s\n%v", stdout, stderr, err)
+	if stdout, stderr, err := TestHelper.HelmInstall("linkerd-edge/linkerd-crds", "linkerd-crds", args...); err != nil {
+		linkerdtestutil.AnnotatedFatalf(t, "'helm install' command failed",
+			"'helm install' command failed\n%s\n%s", stdout, stderr)
+	}
+
+	if stdout, stderr, err := TestHelper.HelmInstall("linkerd-edge/linkerd-control-plane", "linkerd-control-plane", args...); err != nil {
+		linkerdtestutil.AnnotatedFatalf(t, "'helm install' command failed",
+			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}
 
 	// Check if linkerd is ready
@@ -159,7 +168,7 @@ func TestSMIAdaptorWithHelm(t *testing.T) {
 	}...)
 
 	if stdout, stderr, err := TestHelper.HelmInstall(TestHelper.GetSMIHelmChart(), "linkerd-smi", smiArgs...); err != nil {
-		linkerdtestutil.AnnotatedFatalf(t, "'helm install' command failed\n%s\n%s\n%v", stdout, stderr, err)
+		linkerdtestutil.AnnotatedFatalf(t, "'helm install' command failed", "'helm install' command failed\n%s\n%s\n%v", stdout, stderr, err)
 	}
 
 	o, err := TestHelper.Kubectl("", "--namespace=linkerd-smi", "rollout", "status", "--timeout=60m", "deploy/smi-adaptor")


### PR DESCRIPTION
Integration tests currently do not pass because they install the current edge release of Linkerd but have not been updated to use the new Linkerd Helm charts since 2.12.  

We update the integration tests to use the proper new Linkerd helm charts.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
