### PR TITLE
Use helm chart version in helm integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
 env:
   GH_ANNOTATION: true
+  CHART_VERSION: 1.0.1
 jobs:
   docker_build:
     runs-on: ubuntu-20.04
@@ -98,7 +99,7 @@ jobs:
       if: ${{ matrix.test == 'helm' }}
       run: |
           projectdir=$(pwd)
-          GO111MODULE=on go test --failfast --mod=readonly "./test" --linkerd="$HOME/.linkerd2/bin/linkerd" --helm-path="$projectdir/bin/helm" --smi-helm-chart="$projectdir/charts/linkerd-smi" --smi-helm-version="$TAG" --integration-tests
+          GO111MODULE=on go test --failfast --mod=readonly "./test" --linkerd="$HOME/.linkerd2/bin/linkerd" --helm-path="$projectdir/bin/helm" --smi-helm-chart="$projectdir/charts/linkerd-smi" --smi-helm-version="$CHART_VERSION" --integration-tests
     - name: Run CLI Integration Tests
       if: ${{ matrix.test == 'cli' }}
       run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,6 @@ permissions:
   contents: read
 env:
   GH_ANNOTATION: true
-  CHART_VERSION: 1.0.1
 jobs:
   docker_build:
     runs-on: ubuntu-20.04
@@ -99,7 +98,7 @@ jobs:
       if: ${{ matrix.test == 'helm' }}
       run: |
           projectdir=$(pwd)
-          GO111MODULE=on go test --failfast --mod=readonly "./test" --linkerd="$HOME/.linkerd2/bin/linkerd" --helm-path="$projectdir/bin/helm" --smi-helm-chart="$projectdir/charts/linkerd-smi" --smi-helm-version="$CHART_VERSION" --integration-tests
+          GO111MODULE=on go test --failfast --mod=readonly "./test" --linkerd="$HOME/.linkerd2/bin/linkerd" --helm-path="$projectdir/bin/helm" --smi-helm-chart="$projectdir/charts/linkerd-smi" --smi-helm-version="$TAG" --integration-tests
     - name: Run CLI Integration Tests
       if: ${{ matrix.test == 'cli' }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ permissions:
   packages: write
 env:
   GH_ANNOTATION: true
+  CHART_VERSION: 1.0.1
 jobs:
   docker_build:
     runs-on: ubuntu-20.04
@@ -108,8 +109,7 @@ jobs:
       if: ${{ matrix.test == 'helm' }}
       run: |
           projectdir=$(pwd)
-          shorttag="${TAG#v}"
-          go test --failfast --mod=readonly "./test" --linkerd="$HOME/.linkerd2/bin/linkerd" --helm-path="$projectdir/bin/helm" --smi-helm-chart="$projectdir/build-archives/helm/linkerd-smi-$shorttag.tgz" --integration-tests
+          go test --failfast --mod=readonly "./test" --linkerd="$HOME/.linkerd2/bin/linkerd" --helm-path="$projectdir/bin/helm" --smi-helm-chart="$projectdir/build-archives/helm/linkerd-smi-$CHART_VERSION.tgz" --integration-tests
     - name: Run CLI Integration Tests
       if: ${{ matrix.test == 'cli' }}
       run: |


### PR DESCRIPTION
PR https://github.com/linkerd/linkerd-smi/pull/20 updated SMI so that the app version was distinct from the chart version.  This means that, as of this release, the chart version is 1.0.1 whereas the app version is v0.2.1.  However, the Helm integration test is still wired to use the app version and attempts to load the v0.2.1 of the Helm chart, which does not exist.

Update the Helm integration test to use the Helm chart version instead.  Note that this is currently hard coded in the release workflow and will need to be updated each time the Helm chart version is changed.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
