### PR TITLE
Use the correct helm chart version when creating GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         path: build-archives
     - name: Generate SHA256SUMS
       run: |
-        ./bin/generate-sha256sums $TAG
+        ./bin/generate-sha256sums $TAG $CHART_VERSION
     - id: set-env
       run: echo "::set-output name=tag::$(echo $TAG)"
     - name: Create release

--- a/bin/generate-sha256sums
+++ b/bin/generate-sha256sums
@@ -2,10 +2,11 @@
 
 set -eu
 
-if [ $# -eq 1 ]; then
+if [ $# -eq 2 ]; then
     tag=${1:-}
+    chart_version=${2:-}
 else
-    echo "usage: ${0##*/} tag" >&2
+    echo "usage: ${0##*/} tag chart_version" >&2
     exit 64
 fi
 
@@ -25,5 +26,5 @@ for os in $OS; do
 done
 
 # generate for helm chart
-cp build-archives/helm/linkerd-smi-"$shorttag".tgz ./target/release
-openssl dgst -sha256 ./target/release/linkerd-smi-"$shorttag".tgz | awk '{print $2}' > "./target/release/linkerd-smi-$shorttag.tgz.sha256"
+cp build-archives/helm/linkerd-smi-"$chart_version".tgz ./target/release
+openssl dgst -sha256 ./target/release/linkerd-smi-"$chart_version".tgz | awk '{print $2}' > "./target/release/linkerd-smi-$chart_version.tgz.sha256"


### PR DESCRIPTION
Similar to https://github.com/linkerd/linkerd-smi/pull/53, now that the Helm chart version is different from the release version, we need to use the Helm chart version when generating checksums to upload to the releases page during a release.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
