### PR TITLE
Remove redundant globs from github release artifact list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,9 +153,7 @@ jobs:
           ./target/release/linkerd-smi-*.tgz
           ./target/release/linkerd-smi-*.tgz.sha256
           ./target/release/linkerd-smi-*-darwin*
-          ./target/release/linkerd-smi-*-darwin*.sha256
           ./target/release/linkerd-smi-*-linux-*
-          ./target/release/linkerd-smi-*-linux-*.sha256
           ./target/release/linkerd-smi-*-windows.exe
           ./target/release/linkerd-smi-*-windows.exe.sha256
   chart_deploy:


### PR DESCRIPTION
The "Create Release" github action contained redundant file globs which listed the same release artifact multiple times.  For [some reason](https://github.com/softprops/action-gh-release/issues/210), this causes the action to encounter a 404 error and fail.

Remove the redundant globs so that each file is listed only once.


<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
