### PR TITLE
controll curl image per variable

### DIFF
--- a/charts/linkerd-smi/templates/namespace-metadata.yaml
+++ b/charts/linkerd-smi/templates/namespace-metadata.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: namespace-metadata
       containers:
       - name: namespace-metadata
-        image: curlimages/curl:7.78.0
+        image: {{ .Values.namespaceMetadata.curlImage }}
         command: ["/bin/sh"]
         args:
         - -c

--- a/charts/linkerd-smi/values.yaml
+++ b/charts/linkerd-smi/values.yaml
@@ -19,3 +19,6 @@ adaptor:
   nodeSelector: {}
   # -- Tolerations for the adaptor instance
   tolerations: []
+
+namespaceMetadata:
+  curlImage: curlimages/curl:7.78.0


### PR DESCRIPTION
```
Subject

Curl Image in charts/linkerd-smi/templates/namespace-metadata.yaml

Problem

We want to using this in a private cloud and using our own Dockerrepository

Solution

Controll Curl image per Value.yaml

Fixes #11234


Signed-off-by: Kevin Bock <kevinbock87@googlemail.com>

Greatings Kevin 
```