### PR TITLE
adding runAsUser option to linkerd-smi adaptor chart

### DIFF
--- a/charts/linkerd-smi/README.md
+++ b/charts/linkerd-smi/README.md
@@ -68,6 +68,7 @@ Kubernetes: `>=1.16.0-0`
 | adaptor.image.tag | string | `"linkerdSMIVersionValue"` | Docker image tag for the adaptor instance |
 | adaptor.nodeSelector | object | `{}` | Node selector for the adaptor instance |
 | adaptor.resources | object | `{"limits":{"cpu":"100m","memory":"20Mi"},"requests":{"cpu":"100m","memory":"20Mi"}}` | SMI adaptor resource requests & limits |
+| adaptor.runAsUser | int | `65534` | User ID for the SMI adaptor component |
 | adaptor.tolerations | list | `[]` | Tolerations for the adaptor instance |
 | clusterDomain | string | `"cluster.local"` | Kubernetes DNS Domain name to use |
 | imagePullSecrets | list | `[]` | imagePullSecrets to apply to all ServiceAccounts for pulling images from private registries |

--- a/charts/linkerd-smi/templates/adaptor.yaml
+++ b/charts/linkerd-smi/templates/adaptor.yaml
@@ -54,3 +54,5 @@ spec:
             memory: {{ .memory }}
         {{- end }}
       serviceAccountName: smi-adaptor
+      securityContext:
+        runAsUser: {{.Values.adaptor.runAsUser}}

--- a/charts/linkerd-smi/values.yaml
+++ b/charts/linkerd-smi/values.yaml
@@ -19,6 +19,9 @@ adaptor:
     tag: linkerdSMIVersionValue
     # -- Pull policy  for the adaptor instance
     pullPolicy: IfNotPresent
+  
+  # -- User ID for the SMI adaptor component
+  runAsUser: 65534
 
   # -- SMI adaptor resource requests & limits
   resources:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -30,7 +30,6 @@ spec:
     spec:
       containers:
       - args:
-        - smi-adaptor
         - -cluster-domain=cluster.local
         image: cr.l5d.io/linkerd/smi-adaptor:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -46,6 +45,8 @@ spec:
             cpu: 100m
             memory: 20Mi
       serviceAccountName: smi-adaptor
+      securityContext:
+        runAsUser: 65534
 ---
 ###
 ### SMI Adaptor Service


### PR DESCRIPTION
**Subject**

adding runAsUser option to linkerd-smi adaptor chart

**Problem**

Certain environments require custom `runAsUser` settings which we do not currently supply out of the box for the SMI extension.

**Solution**

Added `runAsUser` option to the linkerd-smi adaptor chart

**Validation**

**Fixes** #[[11170](https://github.com/linkerd/linkerd2/issues/11170)]

Signed-off-by: Alen Haric (deusxanima) aharic88@gmail.com
