### PR TITLE
adding custom resource configuration option to linkerd-smi adaptor

### DIFF
--- a/charts/linkerd-smi/templates/adaptor.yaml
+++ b/charts/linkerd-smi/templates/adaptor.yaml
@@ -43,6 +43,17 @@ spec:
         ports:
         - containerPort: 9995
           name: admin-http
+        {{- with .Values.adaptor.resources.requests }}
+        resources:
+          requests:
+            cpu: {{ .cpu }}
+            memory: {{ .memory }}
+        {{- end }}
+        {{- with .Values.adaptor.resources.limits }}
+          limits:
+            cpu: {{ .cpu }}
+            memory: {{ .memory }}
+        {{- end }}
       serviceAccountName: smi-adaptor
       securityContext:
         runAsUser: {{.Values.adaptor.runAsUser}}

--- a/charts/linkerd-smi/templates/adaptor.yaml
+++ b/charts/linkerd-smi/templates/adaptor.yaml
@@ -44,3 +44,5 @@ spec:
         - containerPort: 9995
           name: admin-http
       serviceAccountName: smi-adaptor
+      securityContext:
+        runAsUser: {{.Values.adaptor.runAsUser}}

--- a/charts/linkerd-smi/values.yaml
+++ b/charts/linkerd-smi/values.yaml
@@ -12,6 +12,9 @@ adaptor:
     tag: linkerdSMIVersionValue
     # -- Pull policy  for the adaptor instance
     pullPolicy: IfNotPresent
+  
+  # -- User ID for the SMI adaptor component
+  runAsUser: 65534
 
   # -- Affinity for the adaptor instance
   affinity: {}

--- a/charts/linkerd-smi/values.yaml
+++ b/charts/linkerd-smi/values.yaml
@@ -16,9 +16,19 @@ adaptor:
   # -- User ID for the SMI adaptor component
   runAsUser: 65534
 
+  # -- SMI adaptor resource requests & limits
+  resources:
+    requests:
+      cpu: "100m" 
+      memory: "20Mi" 
+    limits:
+      cpu: "100m" 
+      memory: "20Mi" 
+
   # -- Affinity for the adaptor instance
   affinity: {}
   # -- Node selector for the adaptor instance
   nodeSelector: {}
   # -- Tolerations for the adaptor instance
   tolerations: []
+  


### PR DESCRIPTION
**Subject**

adding custom resource configuration option to linkerd-smi adaptor

**Problem**

Some org security policies and third-party integrations require limits to be set on all resources in order to be installed in a cluster. Currently the linkerd-smi chart is missing the ability to do this out of the box.

**Solution**

added custom resource configuration option to linkerd-smi values.yaml

**Fixes** #[[11305](https://github.com/linkerd/linkerd2/issues/11305)]

Alen Haric (deusxanima) aharic88@gmail.com