### PR TITLE
Parse flags in the adaptor

### DIFF
--- a/adaptor/main.go
+++ b/adaptor/main.go
@@ -26,6 +26,11 @@ func main() {
 	clusterDomain := cmd.String("cluster-domain", "cluster.local", "kubernetes cluster domain")
 	workers := cmd.Int("worker-threads", 2, "number of concurrent goroutines to process the workqueue")
 
+	err := cmd.Parse(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Error parsing flags: %s", err)
+	}
+
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 


### PR DESCRIPTION
The SMI adaptor defines a number of flags, but doesn't parse the command args.  This means that all of these flags will keep their default values, even if different values are passed to the flags.

We parse the args so that the flags get populated with any passed values.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
