### PR TITLE
Bump Helm chart version

### DIFF
--- a/charts/linkerd-smi/Chart.yaml
+++ b/charts/linkerd-smi/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-# this version will be updated by the CI before publishing the Helm tarball
 description: |
   The Linkerd-SMI extension adds SMI adaptor to the Linkerd install
 home: https://linkerd.io
@@ -9,7 +8,7 @@ kubeVersion: ">=1.16.0-0"
 name: linkerd-smi
 sources:
 - https://github.com/linkerd/linkerd-smi/
-version: 1.0.1
+version: 1.0.2
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-smi/README.md
+++ b/charts/linkerd-smi/README.md
@@ -2,7 +2,7 @@
 
 The Linkerd-SMI extension adds SMI adaptor to the Linkerd install
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 


### PR DESCRIPTION
Fixes linkerd/linkerd2#11473 directly. As a followup, we'll add a release doc covering this step.

