### PR TITLE
fix: respect -cluster-domain

### DIFF
--- a/charts/linkerd-smi/templates/adaptor.yaml
+++ b/charts/linkerd-smi/templates/adaptor.yaml
@@ -35,7 +35,6 @@ spec:
       {{- end }}
       containers:
       - args:
-        - smi-adaptor
         - -cluster-domain={{.Values.clusterDomain}}
         image: {{.Values.adaptor.image.registry}}/{{.Values.adaptor.image.name}}:{{.Values.adaptor.image.tag}}
         imagePullPolicy: {{.Values.adaptor.image.pullPolicy}}


### PR DESCRIPTION
### What is the issue?
Installing linkerd SMI using the official helm chart with custom clusterDomain resultes in:
```
time="2023-12-04T14:37:37Z" level=info msg="Using cluster domain: cluster.local"
...
```
(The parameter is ignored)
### How can it be reproduced?
```
helm install linkerd-smi -n linkerd-smi --create-namespace linkerd-smi/linkerd-smi --set clusterDomain=cluster-ox1-test.local
```
### Possible solution
Remove `smi-adaptor` from the `args` list in the helm chart. The container entrypoint [is already set to `/smi-adaptor`](https://github.com/linkerd/linkerd-smi/blob/main/adaptor/Dockerfile#L14).