### PR TITLE
Replaced kind action with dev image setup-tools

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -78,10 +78,9 @@ jobs:
       with:
         name: build-archives
         path: build-archives
-    - name: Create k8s Kind Cluster
-      uses: engineerd/setup-kind@v0.5.0
-      with:
-        version: "v0.11.1"
+    - name: Create k8s Cluster
+      uses: linkerd/dev/actions/setup-tools@v42
+      run: just-k3d create use
     - name: Load the SMI extension CLI and Images
       run: |
         mkdir -p $HOME/.linkerd2/bin
@@ -90,7 +89,7 @@ jobs:
         chmod +x $HOME/.linkerd2/bin/linkerd-smi
 
         # load image into the cluster
-        kind load image-archive build-archives/smi-adaptor.tar
+        just-k3d import build-archives/smi-adaptor.tar
     - name: Install the Linkerd CLI
       run : |
         curl -sL https://run.linkerd.io/install-edge | sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,9 @@ jobs:
       with:
         name: build-archives
         path: build-archives
-    - name: Create k8s Kind Cluster
-      uses: engineerd/setup-kind@v0.5.0
-      with:
-        version: "v0.11.1"
+    - name: Create k8s Cluster
+      uses: linkerd/dev/actions/setup-tools@v42
+      run: just-k3d create use
     - name: Load the SMI extension CLI and Images
       run: |
         mkdir -p $HOME/.linkerd2/bin


### PR DESCRIPTION
Removed no longer supported `engineerd/setup-kind` action, replaced with straight k3d commands, using the minimum supported k8s version (v1.22).