### PR TITLE
Changes for v0.2.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
   packages: write
 env:
   GH_ANNOTATION: true
-  CHART_VERSION: 1.0.3
+  CHART_VERSION: 1.0.4
 jobs:
   docker_build:
     runs-on: ubuntu-20.04

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## v0.2.7
+
+- Allowed setting resource requirements for the smi-adaptor
+- Added ability to set `runAsUser` entry for the smi-adaptor
+- Fixed `clusterDomain` config (it was being ignored)
+
 ## v0.2.6
 
 This release adds `imagePullSecrets` support, for pulling images from private

--- a/charts/linkerd-smi/Chart.yaml
+++ b/charts/linkerd-smi/Chart.yaml
@@ -8,7 +8,7 @@ kubeVersion: ">=1.16.0-0"
 name: linkerd-smi
 sources:
 - https://github.com/linkerd/linkerd-smi/
-version: 1.0.3
+version: 1.0.4
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-smi/README.md
+++ b/charts/linkerd-smi/README.md
@@ -2,7 +2,7 @@
 
 The Linkerd-SMI extension adds SMI adaptor to the Linkerd install
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>
 


### PR DESCRIPTION
- Allowed setting resource requirements for the smi-adaptor
- Added ability to set `runAsUser` entry for the smi-adaptor
- Fixed `clusterDomain` config (it was being ignored)